### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ func (db *DB) getItemByID(itemID string) (Item, error) {
 
 	var i Item
 	if err := db.Conn.Get(&i, sql, itemID); err != nil {
-		return Item{}, fmt.Errof("failed to get item by ID: %v", err) // No error!
+		return Item{}, fmt.Errorf("failed to get item by ID: %v", err) // No error!
 	}
 
 	return i, nil


### PR DESCRIPTION
Fix typo in example code.

Also, golangci-lint complains about:

```
non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
```

because of `%v`. I can send another PR for that.