### PR TITLE
Fix false-positives for github.com/pkg/errors functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ ignoreSigs:
 - .Wrap(
 - .Wrapf(
 - .WithMessage(
+- .WithMessagef(
+- .WithStack(
 ```
 
 ## Usage

--- a/wrapcheck/testdata/ignore_pkg_errors/main.go
+++ b/wrapcheck/testdata/ignore_pkg_errors/main.go
@@ -24,5 +24,13 @@ func do() error {
 		return errors.WithMessage(err, "uh oh")
 	}
 
-	return nil
+	if err != nil {
+		return errors.WithMessagef(err, "uh %s", "oh")
+	}
+
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.New("uh oh")
 }

--- a/wrapcheck/wrapcheck.go
+++ b/wrapcheck/wrapcheck.go
@@ -16,6 +16,8 @@ var DefaultIgnoreSigs = []string{
 	".Wrap(",
 	".Wrapf(",
 	".WithMessage(",
+	".WithMessagef(",
+	".WithStack(",
 }
 
 // WrapcheckConfig is the set of configuration values which configure the


### PR DESCRIPTION
Add support for `errors.WithMessagef(` and `errors.WithStack(`


Wrapcheck complains about the next code:

```
package store

import (
	"database/sql"
	stderrors "errors"

	"github.com/pkg/errors"
)

var ErrNoRowsAffected = stderrors.New("no rows affected")
var ErrMultipleRowsAffected = stderrors.New("multiple rows affected")

// EnsureOneRowAffected ensures that a single row was affected by db.ExecWithResult.
func EnsureOneRowAffected(res sql.Result, err error) error {
	if err != nil {
		return err
	}

	rows, err := res.RowsAffected()
	if err != nil {
		return errors.Wrap(err, "could not fetch information about affected rows")
	}

	if rows == 0 {
		return errors.WithStack(ErrNoRowsAffected)
	}

	if rows > 1 {
		return errors.WithStack(ErrMultipleRowsAffected)
	}

	return nil
}
```

```
error returned from external package is unwrapped: sig: func github.com/pkg/errors.WithStack(err error) error (wrapcheck)
                return errors.WithStack(ErrNoRowsAffected)
```
