### PR TITLE
chore: remove unnecessary type assertion

### DIFF
--- a/wrapcheck/wrapcheck.go
+++ b/wrapcheck/wrapcheck.go
@@ -94,10 +94,6 @@ func run(cfg WrapcheckConfig) func(*analysis.Pass) (interface{}, error) {
 	return func(pass *analysis.Pass) (interface{}, error) {
 		for _, file := range pass.Files {
 			ast.Inspect(file, func(n ast.Node) bool {
-				if _, ok := n.(*ast.AssignStmt); ok {
-					return true
-				}
-
 				ret, ok := n.(*ast.ReturnStmt)
 				if !ok {
 					return true


### PR DESCRIPTION
Hello @tomarrell ! I noticed what appears to be an unnecessary type assertion in the wrapcheck linter. Here is a PR to remove the unnecessary code.

I have verified that this passes the test suite. If there's anything else I can do to help, please don't hesitate to let me know. Thanks.