### PR TITLE
dev: refactor `regexp` usage

### DIFF
--- a/wrapcheck/testdata/config_ignoreSigRegexps_fail/.wrapcheck.yaml
+++ b/wrapcheck/testdata/config_ignoreSigRegexps_fail/.wrapcheck.yaml
@@ -1,0 +1,2 @@
+ignoreSigRegexps:
+- json\.[a-zA-Z0-9_-

--- a/wrapcheck/wrapcheck.go
+++ b/wrapcheck/wrapcheck.go
@@ -376,7 +376,7 @@ func compileRegexps(regexps []string) ([]*regexp.Regexp, error) {
 	for _, reg := range regexps {
 		re, err := regexp.Compile(reg)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse regexp %s: %v\n", reg, err)
+			return nil, fmt.Errorf("unable to compile regexp %s: %v\n", reg, err)
 		}
 
 		compiledRegexps = append(compiledRegexps, re)

--- a/wrapcheck/wrapcheck_test.go
+++ b/wrapcheck/wrapcheck_test.go
@@ -59,15 +59,15 @@ func TestAnalyzer(t *testing.T) {
 }
 
 func TestRegexpCompileFail(t *testing.T) {
-	// A config file exists, use it
 	configFile, err := os.ReadFile("./testdata/config_ignoreSigRegexps_fail/.wrapcheck.yaml")
 	assert.NoError(t, err)
 
 	var config WrapcheckConfig
 	assert.NoError(t, yaml.Unmarshal(configFile, &config))
-	a := NewAnalyzer(config)
-	results, err := a.Run(nil) // Doesn't matter what we pass
 
+	a := NewAnalyzer(config)
+
+	results, err := a.Run(nil) // Doesn't matter what we pass
 	assert.Nil(t, results)
-	assert.Contains(t, err.Error(), "unable to parse regexp json\\.[a-zA-Z0-9_-")
+	assert.Contains(t, err.Error(), "unable to compile regexp json\\.[a-zA-Z0-9_-")
 }


### PR DESCRIPTION
This PR intends to bring the next features/fixes to `wrapcheck`:

1) avoid compiling regexp rules into `regexp.Regexp` for checking each error returning function.
2) removing `os.Exit(1)` in case fail to compile `regexp` rule from the codebase ( we can't handle such cases in `golangci-lint`: output is hidden, so no log messages received, which ends in no issues or errors comes from `wrapcheck` if bad regexp provided).

P.S. The rest of the coding is changed by `gofumpt` automatically.
P.P.S. It would be also great to release `fix` changes asap (so we update `golangci-lint`).