### PR TITLE
Feature/ignore interface regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ ignorePackageGlobs:
 - encoding/*
 - github.com/pkg/*
 
-# An array of strings which specify regular expressions of interface names.
-# If matched will skip wrapcheck analysis for errors returned from a
-# function whose call is defined on the given interfaces. Allows to explicitly 
-# define interface names with mandated methods to ignore 
+# ignoreInterfaceRegexps defines a list of regular expressions which, if matched
+# to a underlying interface name, will ignore unwrapped errors returned from a
+# function whose call is defined on the given interface.
 ignoreInterfaceRegexps:
 - ^(?i)c(?-i)ach(ing|e)
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ ignoreSigRegexps:
 ignorePackageGlobs:
 - encoding/*
 - github.com/pkg/*
+
+# An array of strings which specify regular expressions of interface names.
+# If matched will skip wrapcheck analysis for errors returned from a
+# function whose call is defined on the given interfaces. Allows to explicitly 
+# define interface names with mandated methods to ignore 
+ignoreInterfaceRegexps:
+- ^(?i)c(?-i)ach(ing|e)
 ```
 
 ## Usage

--- a/wrapcheck/testdata/config_ignoreInterfaceRegexps/.wrapcheck.yaml
+++ b/wrapcheck/testdata/config_ignoreInterfaceRegexps/.wrapcheck.yaml
@@ -1,0 +1,2 @@
+ignoreInterfaceRegexps:
+- (errorer|error)

--- a/wrapcheck/testdata/config_ignoreInterfaceRegexps/main.go
+++ b/wrapcheck/testdata/config_ignoreInterfaceRegexps/main.go
@@ -18,7 +18,7 @@ func do(fn errorer) error {
 	var str string
 	err := fn.Decode(&str)
 	if err != nil {
-		return err // errorer interface ignored
+		return err // errorer interface ignored as per `ignoreInterfaceRegexps`
 	}
 
 	return nil

--- a/wrapcheck/testdata/config_ignoreInterfaceRegexps/main.go
+++ b/wrapcheck/testdata/config_ignoreInterfaceRegexps/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type errorer interface {
+	Decode(v interface{}) error
+}
+
+func main() {
+	d := json.NewDecoder(strings.NewReader("hello world"))
+	do(d)
+}
+
+func do(fn errorer) error {
+	var str string
+	err := fn.Decode(&str)
+	if err != nil {
+		return err // errorer interface ignored
+	}
+
+	return nil
+}

--- a/wrapcheck/wrapcheck.go
+++ b/wrapcheck/wrapcheck.go
@@ -51,11 +51,11 @@ type WrapcheckConfig struct {
 	// unwrapped.
 	//
 	// For example, an ignoreSigRegexp of `[]string{"\.New.*Err\("}`` will ignore errors
-	// returned from any signture whose method name starts with "New" and ends with "Err"
+	// returned from any signature whose method name starts with "New" and ends with "Err"
 	// due to the signature matching the regular expression `\.New.*Err\(`.
 	//
 	// Note that this is similar to the ignoreSigs configuration, but provides
-	// slightly more flexibility in defining rules by which signtures will be
+	// slightly more flexibility in defining rules by which signatures will be
 	// ignored.
 	IgnoreSigRegexps []string `mapstructure:"ignoreSigRegexps" yaml:"ignoreSigRegexps"`
 
@@ -264,15 +264,11 @@ func reportUnwrapped(pass *analysis.Pass, call *ast.CallExpr, tokenPos token.Pos
 // isInterface returns whether the function call is one defined on an interface.
 func isInterface(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
 	_, ok := pass.TypesInfo.TypeOf(sel.X).Underlying().(*types.Interface)
-	if ok {
-		fmt.Println(types.TypeString(pass.TypesInfo.TypeOf(sel.X), func(p *types.Package) string {
-			return p.Name()
-		}))
-	}
+
 	return ok
 }
 
-// isFromotherPkg returns whether the function is defined in the pacakge
+// isFromotherPkg returns whether the function is defined in the package
 // currently under analysis or is considered external. It will ignore packages
 // defined in config.IgnorePackageGlobs.
 func isFromOtherPkg(pass *analysis.Pass, sel *ast.SelectorExpr, config WrapcheckConfig) bool {


### PR DESCRIPTION
Hi Tom! 
This PR intends to bring flexibility to wrapcheck with errors returned from Interfaces  types:


Allows ignore unwrapped errors returned from interfaces. Define regexps rules to explicitly ignore underlying interfaces with mandated methods to ignore, according to the interface names. Even though this could technically be done with thought-out ignoreSigRegexps, this allows to explicitly and cleanly define rules in the config to define sub cases of IsInterface.

PS: fixed typos