### PR TITLE
fix: check interface package against ignorePackageGlobs

### DIFF
--- a/wrapcheck/testdata/config_ignorePackageGlobs_interface/.wrapcheck.yaml
+++ b/wrapcheck/testdata/config_ignorePackageGlobs_interface/.wrapcheck.yaml
@@ -1,0 +1,2 @@
+ignorePackageGlobs:
+  - encoding/*

--- a/wrapcheck/testdata/config_ignorePackageGlobs_interface/main.go
+++ b/wrapcheck/testdata/config_ignorePackageGlobs_interface/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+)
+
+func main() {
+	do(&time.Time{})
+}
+
+func do(fn json.Unmarshaler) error {
+	err := fn.UnmarshalJSON([]byte{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR introduces checking of the interface's package against the configured `ignorePackageGlobs` values. 

Previously, only functions called directly from other packages had their packages checked against this option, however this behaviour was unintuitive. This change checks the interface package as well, ignoring interfaces which originate from a package matching a glob pattern.

Closes #34 