### PR TITLE
feat: ignore Go 1.20 errors.Join() sig by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ ignoreSigs:
 - .Errorf(
 - errors.New(
 - errors.Unwrap(
+- errors.Join(
 - .Wrap(
 - .Wrapf(
 - .WithMessage(

--- a/wrapcheck/wrapcheck.go
+++ b/wrapcheck/wrapcheck.go
@@ -16,6 +16,7 @@ var DefaultIgnoreSigs = []string{
 	".Errorf(",
 	"errors.New(",
 	"errors.Unwrap(",
+	"errors.Join(",
 	".Wrap(",
 	".Wrapf(",
 	".WithMessage(",


### PR DESCRIPTION
After upgrading to Go 1.20 and using the new `errors.Join()` from the standard library, there is a false positive from `wrapcheck` saying that `error returned from external package is unwrapped`, when `errors.Join()` is now supposed to be an idiomatic way to wrap multiple errors from external packages.

More info in the Go 1.20 release notes:

https://tip.golang.org/doc/go1.20#errors