### PR TITLE
Add config option to extend `ignoreSigs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ ignoreSigs:
 - .WithMessagef(
 - .WithStack(
 
+
+# An array of strings specifying additional substrings of signatures to ignore.
+# Unlike ignoreSigs, this option extends the default set (or the set specified
+# in ignoreSigs) without replacing it entirely. This allows you to add specific
+# signatures to the ignore list while retaining the defaults or any items in
+# ignoreSigs.
+extraIgnoreSigs:
+- .CustomError(
+- .SpecificWrap(
+
 # An array of strings which specify regular expressions of signatures to ignore.
 # This is similar to the ignoreSigs configuration above, but gives slightly more
 # flexibility.

--- a/wrapcheck/testdata/config_extraIgnoreSigs/.wrapcheck.yaml
+++ b/wrapcheck/testdata/config_extraIgnoreSigs/.wrapcheck.yaml
@@ -1,0 +1,5 @@
+extraIgnoreSigs:
+- json.Marshal(
+
+ignoreSigs:
+  - errors.New(

--- a/wrapcheck/testdata/config_extraIgnoreSigs/main.go
+++ b/wrapcheck/testdata/config_extraIgnoreSigs/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+func main() {
+	do()
+}
+
+func do() error {
+	// no issue with function in 'extraIgnoreSigs'
+	_, err := json.Marshal(struct{}{})
+	if err != nil {
+		return err
+	}
+
+	// expect issue for function that is not ignored
+	res := struct{}{}
+	if err := json.Unmarshal([]byte("{}"), &res); err != nil {
+		return err // want `error returned from external package is unwrapped`
+	}
+
+	// no issue with function in 'ignoreSigs'
+	return errors.New("Some error")
+}

--- a/wrapcheck/wrapcheck.go
+++ b/wrapcheck/wrapcheck.go
@@ -44,6 +44,10 @@ type WrapcheckConfig struct {
 	// list to your config.
 	IgnoreSigs []string `mapstructure:"ignoreSigs" yaml:"ignoreSigs"`
 
+	// ExtraIgnoreSigs defines an additional list of signatures to ignore, on
+	// top of IgnoreSigs.
+	ExtraIgnoreSigs []string `mapstructure:"extraIgnoreSigs" yaml:"extraIgnoreSigs"`
+
 	// IgnoreSigRegexps defines a list of regular expressions which if matched
 	// to the signature of the function call returning the error, will be ignored. This
 	// allows you to specify functions that wrapcheck will not report as
@@ -276,7 +280,7 @@ func reportUnwrapped(
 
 	// Check for ignored signatures
 	fnSig := pass.TypesInfo.ObjectOf(sel.Sel).String()
-	if contains(cfg.IgnoreSigs, fnSig) {
+	if contains(cfg.IgnoreSigs, fnSig) || contains(cfg.ExtraIgnoreSigs, fnSig) {
 		return
 	} else if containsMatch(regexpsSig, fnSig) {
 		return


### PR DESCRIPTION
The use case for this is I would like to add another signature to ignore, but still being able to rely on the default list is convenient, since I don't have to manually sync my list with any future changes to the defaults.

closes #54